### PR TITLE
Bump actions/download-artifact to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -170,7 +170,7 @@ jobs:
 
     steps:
       - name: Fetch Release Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: release-artifacts
           path: build


### PR DESCRIPTION
Fixes the following error:

```
This request has been automatically failed because it uses a deprecated version of `actions/download-artifact: v3`.
```